### PR TITLE
Remove fullscreen radius

### DIFF
--- a/src/styles/_core.scss
+++ b/src/styles/_core.scss
@@ -360,6 +360,10 @@
 
   &.fullscreen {
     @include fullscreen;
+    .slideMode-Dashboard {
+      border-bottom-right-radius: 0;
+      border-bottom-left-radius: 0;
+    }
   }
 
   &:fullscreen {


### PR DESCRIPTION
## What

On full screen, Dashboard sticks to the bottom of the screen, so a rounded corner is unnecessary.
Therefore, it deleted.
