### PR TITLE
Improve styles

### DIFF
--- a/src/styles/_core.scss
+++ b/src/styles/_core.scss
@@ -3,21 +3,6 @@
   100% { opacity: 1.0 }
 }
 
-@mixin fullscreen {
-  z-index: 0;
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
-  margin: 0;
-  height: 100%;
-}
-
 .slideMode {
   user-select: none;
   margin-bottom: 40px;
@@ -356,43 +341,23 @@
     white-space: pre;
   }
 
-  // Fullscreen pseudo class does not work to write in mutilple selector.
-
   &.fullscreen {
-    @include fullscreen;
+    z-index: 0;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    margin: 0;
+    height: 100%;
+
     .slideMode-Dashboard {
       border-bottom-right-radius: 0;
       border-bottom-left-radius: 0;
-    }
-  }
-
-  &:fullscreen {
-    @include fullscreen;
-
-    .slide_preview {
-      img {
-        zoom: 1.8;
-      }
-    }
-  }
-
-  &:-moz-full-screen {
-    @include fullscreen;
-
-    .slide_preview {
-      img {
-        width: 80%;
-      }
-    }
-  }
-
-  &:-ms-full-screen {
-    @include fullscreen;
-
-    .slide_preview {
-      img {
-        zoom: 1.8;
-      }
     }
   }
 }

--- a/src/styles/_core.scss
+++ b/src/styles/_core.scss
@@ -342,7 +342,7 @@
   }
 
   &.fullscreen {
-    z-index: 0;
+    z-index: $qiita-slide-mode-fullscreen-z-index;
     position: absolute;
     top: 0;
     bottom: 0;

--- a/src/styles/_core.scss
+++ b/src/styles/_core.scss
@@ -83,24 +83,24 @@
       }
     }
 
-    @media (max-width: $break-point-xs) {
+    @media (max-width: $qiita-slide-mode-break-point-xs) {
       font-size: 1.3em;
     }
 
-    @media (min-width: $break-point-s) {
+    @media (min-width: $qiita-slide-mode-break-point-s) {
       font-size: 1.6em;
     }
 
-    @media (min-width: $break-point-m) {
+    @media (min-width: $qiita-slide-mode-break-point-m) {
       font-size: 1.9em;
     }
 
-    @media (min-width: $break-point-l) {
+    @media (min-width: $qiita-slide-mode-break-point-l) {
       font-size: 2.2em;
     }
 
     .it-MdContent & {
-      @media (min-width: $break-point-l) {
+      @media (min-width: $qiita-slide-mode-break-point-l) {
         font-size: 2em;
       }
     }

--- a/src/styles/_vars.scss
+++ b/src/styles/_vars.scss
@@ -3,3 +3,4 @@ $qiita-slide-mode-break-point-xs: 480px !default;
 $qiita-slide-mode-break-point-s: 770px !default;
 $qiita-slide-mode-break-point-m: 992px !default;
 $qiita-slide-mode-break-point-l: 1200px !default;
+$qiita-slide-mode-fullscreen-z-index: 1000 !default;

--- a/src/styles/_vars.scss
+++ b/src/styles/_vars.scss
@@ -1,5 +1,5 @@
-$qiita-slide-mode-break-point-minimum: 320px;
-$qiita-slide-mode-break-point-xs: 480px;
-$qiita-slide-mode-break-point-s: 770px;
-$qiita-slide-mode-break-point-m: 992px;
-$qiita-slide-mode-break-point-l: 1200px;
+$qiita-slide-mode-break-point-minimum: 320px !default;
+$qiita-slide-mode-break-point-xs: 480px !default;
+$qiita-slide-mode-break-point-s: 770px !default;
+$qiita-slide-mode-break-point-m: 992px !default;
+$qiita-slide-mode-break-point-l: 1200px !default;

--- a/src/styles/_vars.scss
+++ b/src/styles/_vars.scss
@@ -1,5 +1,5 @@
-$break-point-minimum: 320px;
-$break-point-xs: 480px;
-$break-point-s: 770px;
-$break-point-m: 992px;
-$break-point-l: 1200px;
+$qiita-slide-mode-break-point-minimum: 320px;
+$qiita-slide-mode-break-point-xs: 480px;
+$qiita-slide-mode-break-point-s: 770px;
+$qiita-slide-mode-break-point-m: 992px;
+$qiita-slide-mode-break-point-l: 1200px;


### PR DESCRIPTION
- Introduce `$qiita-slide-mode-` prefix to Sass variables. Global variables always face to collision problem. Seriously.
- All package variables should be declared as `!default`.
- Remove unused rules.
- Enable to customize z-index of `.fullscreen`. Proper z-index value strongly depends on where this package runs on.