### PR TITLE
Remove "module" from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@increments/qiita-slide-mode",
   "description": "Qiita's Slide Mode component.",
   "version": "0.2.0",
-  "main": "dist/QiitaSlideMode.js",
+  "main": "dist/index.js",
   "module": "src/index.js",
   "license": "MIT",
   "repository": "increments/qiita-slide-mode",
@@ -15,7 +15,7 @@
   "scripts": {
     "test": "echo We live in an interactive world!",
     "build": "npm run build:jsx && npm run build:dist",
-    "build:dist": "rollup -m -f umd -n QiitaSlideMode -c -i src/index.js -o dist/QiitaSlideMode.js",
+    "build:dist": "(rm -fr dist || true) && rollup -c",
     "build:jsx": "babel -d ./ src/*.jsx",
     "prepare": "npm run build",
     "format": "npm run format:css && npm run format:js",
@@ -35,8 +35,6 @@
     "rollup": "^0.57.1",
     "rollup-plugin-buble": "^0.19.2",
     "rollup-plugin-commonjs": "^9.1.0",
-    "rollup-plugin-node-resolve": "^3.3.0",
-    "rollup-plugin-uglify": "^3.0.0",
     "typescript": "2.7.1"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "description": "Qiita's Slide Mode component.",
   "version": "0.2.0",
   "main": "dist/index.js",
-  "module": "src/index.js",
   "license": "MIT",
   "repository": "increments/qiita-slide-mode",
   "files": [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,8 +1,15 @@
 import buble from "rollup-plugin-buble"
 import commonjs from "rollup-plugin-commonjs"
-import resolve from "rollup-plugin-node-resolve"
-import uglify from "rollup-plugin-uglify"
 
 export default {
-  plugins: [buble({ jsx: "h" }), resolve(), commonjs(), uglify()]
+  input: "./src/index.js",
+  output: {
+    file: "./dist/index.js",
+    format: "cjs",
+    sourcemap: true,
+  },
+  plugins: [
+    commonjs(),
+    buble({ jsx: "h" })
+  ]
 }


### PR DESCRIPTION
TypeScript imports the "module" file. Since TypeScript doesn't transform imported files, our assets includes ES2015 syntax.